### PR TITLE
Fix enhance button redisplay after schema toggle

### DIFF
--- a/content.js
+++ b/content.js
@@ -518,6 +518,10 @@ class SchemaForge {
     if (toggleBtn) {
       toggleBtn.addEventListener('click', () => {
         this.isActive = !this.isActive;
+        // Reset injection flag when toggling to allow button to reappear
+        if (this.isActive) {
+          this.hasInjectedSchema = false;
+        }
         this.updateWidget();
       });
     }
@@ -530,6 +534,8 @@ class SchemaForge {
         if (selectedSchema) {
           this.activeSchema = selectedSchema;
           this.userSelectedSchema = true;
+          // Reset injection flag when changing schemas to allow re-enhancement
+          this.hasInjectedSchema = false;
           this.updateWidget();
           
           // Update button text immediately if button exists
@@ -539,6 +545,8 @@ class SchemaForge {
           }
         } else {
           this.activeSchema = null;
+          // Reset injection flag when clearing schema selection
+          this.hasInjectedSchema = false;
           this.updateWidget();
         }
       });


### PR DESCRIPTION
Reset `hasInjectedSchema` flag to ensure the enhance button redisplays after schema toggling or changes.

The `hasInjectedSchema` flag was not being reset when the extension was toggled off/on or when schemas were changed, preventing the enhance button from reappearing even when it should have. This PR ensures the flag is reset in these scenarios, allowing the button to be recreated.

---

[Open in Web](https://cursor.com/agents?id=bc-bbdd5c39-b2c1-4aa1-8954-4bfa7870df44) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bbdd5c39-b2c1-4aa1-8954-4bfa7870df44) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)