### PR TITLE
Manage schema dropdown and show schemas tab

### DIFF
--- a/content.js
+++ b/content.js
@@ -412,7 +412,7 @@ class SchemaForge {
                   this.isLoadingSchemas ? 
                   '<option value="">Loading schemas...</option>' : 
                   this.schemas.length > 0 ? 
-                  '<option value="">No Schema</option>' + this.schemas.map(s => `<option value="${s.id}" ${this.activeSchema && s.id === this.activeSchema.id ? 'selected' : ''}>${s.name}</option>`).join('') :
+                  this.schemas.map(s => `<option value="${s.id}" ${this.activeSchema && s.id === this.activeSchema.id ? 'selected' : ''}>${s.name}</option>`).join('') :
                   '<option value="">No schemas available</option>'
                 }
               </select>


### PR DESCRIPTION
Remove 'No Schema' dropdown option when schemas are loaded to streamline schema selection.

---

[Open in Web](https://cursor.com/agents?id=bc-bbbf0827-6545-4932-9f85-00f2194a1863) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bbbf0827-6545-4932-9f85-00f2194a1863) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)