### PR TITLE
Remove schema industry tone target textarea

### DIFF
--- a/content.js
+++ b/content.js
@@ -549,14 +549,6 @@ class SchemaForge {
                 </div>
               </div>
               
-              <div id="sf-schema-preview" style="background: #f9fafb; padding: 12px; border-radius: 6px; margin-top: 12px; font-size: 12px; display: ${this.activeSchema ? 'block' : 'none'};">
-                ${this.activeSchema ? `
-                  <h4 style="margin: 0 0 8px 0; color: #1f2937;">${this.activeSchema.company.name}</h4>
-                  <div style="color: #6b7280; margin-bottom: 4px;">Industry: ${this.activeSchema.company.industry}</div>
-                  <div style="color: #6b7280; margin-bottom: 4px;">Tone: ${this.activeSchema.company.tone}</div>
-                  <div style="color: #6b7280;">Target: ${this.activeSchema.personas[0].name}</div>
-                ` : ''}
-              </div>
             </div>
           </div>
           


### PR DESCRIPTION
Remove the schema preview text area displaying industry, tone, and target.

---
<a href="https://cursor.com/background-agent?bcId=bc-5be540d9-0c61-4dbb-b560-e52639fbd345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5be540d9-0c61-4dbb-b560-e52639fbd345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

